### PR TITLE
Sorted string representations to fix flaky tests AnnotationBundleKeyTest

### DIFF
--- a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
+++ b/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.jakarta.rs.base.cfg;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +44,9 @@ public class AnnotationBundleKeyTest
 
     public void testWithClassAnnotations() throws Exception
     {
-        _checkWith(Helper.class.getAnnotations(), Helper.class.getAnnotations());
+        Annotation[] annotations = Helper.class.getAnnotations(); 
+        Arrays.sort(annotations, Comparator.comparing(Annotation::toString)); 
+        _checkWith(annotations, annotations); 
     }
 
     public void testWithMethodAnnotationEquals() throws Exception


### PR DESCRIPTION
**Setup:**
Java version: openjdk 11.0.20.1
Maven version: Apache Maven 3.6.3

**Test Failure**
The test `com.fasterxml.jackson.jakarta.rs.base.cfg.AnnotationBundleKeyTest#testWithClassAnnotations` can fail because the test use java.class.getAnnotations() and the order of the objects returned may not be necessarily maintained. This can be detected by utilizing the [Nondex](https://github.com/TestingResearchIllinois/NonDex) plugin.

**Steps to reproduce:** 
1. `git clone https://github.com/FasterXML/jackson-jakarta-rs-providers`
2. `mvn install -pl base -am -DskipTests`
3. Run the tests 
`mvn -pl base test -Dtests=com.fasterxml.jackson.jakarta.rs.base.cfg.AnnotationBundleKeyTest#testWithClassAnnotations`
4. Run the test with the Nondex tool and observe the test results
    `mvn -pl base edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.fasterxml.jackson.jakarta.rs.base.cfg.AnnotationBundleKeyTest#testWithClassAnnotations`
     - Test passes when Running Nondex in ONE mode `-DnondexMode=ONE` (Assumes deterministic implementation of code but shuffled once different from underlying implementation)
     - Test fails when Running Nondex in FULL mode` -DnondexMode=FULL` (shuffles differently for each call)
     
**Root Cause:**
When running Nondex for the test, the below error occurs stating that the array elements differed at the first index. 
`Internal error: should never differ: arrays first differed at element [1]; expected:<@com.fasterxml.jackson.annotation.JsonPropertyOrder(alphabetic=false, value={"a", "b"})> but was:<@com.fasterxml.jackson.annotation.JsonIgnoreProperties(allowSetters=false, value={}, ignoreUnknown=false, allowGetters=false)`

The [test](https://github.com/FasterXML/jackson-jakarta-rs-providers/blob/b78b1316539e5105349905c0b2621f36dc979d4a/base/src/test/java/com/fasterxml/jackson/jakarta/rs/base/cfg/AnnotationBundleKeyTest.java#L45) verifies if the annotations on the Helper class are consistent and if the order of the annotations returned by `Helper.class.getAnnotations()` is preserved. The test `testWithClassAnnotations` fails because java.class.getAnnotations() returns an array of java.lang.annotation.Annotation objects but the order of the objects may not be maintained. The implementation checks if the annotations are consistent with every call, which might cause the test to fail. 

**Fix:**
java.lang.class.getAnnotations() returns an array but the order may not be maintained. The Fix involves sorting the Annotations object based on their string representation and then, performing the comparision. Sorting the array enforces consistency in comparing the objects.